### PR TITLE
updated to use ts-deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "use-media-stream",
       "version": "1.0.3",
       "license": "MIT",
+      "dependencies": {
+        "ts-deepmerge": "^7.0.0"
+      },
       "devDependencies": {
         "@types/node": "^20.11.5",
         "@types/react": "^18.2.48",
@@ -19,7 +22,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "deepmerge": "^4.3.1",
         "react": ">=16"
       }
     },
@@ -60,15 +62,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -120,6 +113,14 @@
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "build:esm": "tsc",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",
     "prepare": "npm run build"
-
   },
   "engines": {
     "node": ">=16"
@@ -45,7 +44,6 @@
     "url": "git+https://github.com/kothariji/use-media-stream.git"
   },
   "peerDependencies": {
-    "deepmerge": "^4.3.1",
     "react": ">=16"
   },
   "devDependencies": {
@@ -54,5 +52,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "ts-deepmerge": "^7.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { REQUEST_STATES } from './constants';
-import merge from 'deepmerge';
+import { merge } from 'ts-deepmerge';
 
 /**
  * Represents the configuration for using a media stream


### PR DESCRIPTION
deepmerge does not support esm as documented in the readme:

> The ESM entry point was dropped due to a [Webpack bug](https://github.com/webpack/webpack/issues/6584).

so this updates the hook to use a different deep merge dependency that works with esm